### PR TITLE
fix!: compare sorting helper now behaves as expected

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -21,6 +21,8 @@ class NameTable extends BaseElement {
     "Edward Bulwer-Lytton",
     "U.S. Government Accountability Office",
     "The Environmental Protection Agency",
+    "Philip K. Dick",
+    "Eric Jerome Dickey",
   ];
 
   names: { name: string; nameFormatted: string }[];

--- a/src/sortable-names.test.ts
+++ b/src/sortable-names.test.ts
@@ -236,3 +236,22 @@ describe("SortableNames with configured articles", () => {
     expect(sortableArticlesExtended.getSortable(name)).toBe(nameSorted);
   });
 });
+
+describe("SortableNames.compare helper", () => {
+  const sortable = new SortableNames();
+
+  const similarNames = ["Eric Jerome Dickey", "Philip K. Dick"];
+
+  test("correctly handles names that partially match", () => {
+    const sortableSimilarNames = similarNames.map((name) =>
+      sortable.getSortable(name)
+    );
+
+    const sortedSimilarNames = sortableSimilarNames.sort(SortableNames.compare);
+
+    expect(sortedSimilarNames).toStrictEqual([
+      "Dick, Philip K.",
+      "Dickey, Eric Jerome",
+    ]);
+  });
+});

--- a/src/sortable-names.ts
+++ b/src/sortable-names.ts
@@ -361,16 +361,43 @@ class SortableNames {
    * Helper comparator to pass to Array.sort() or Array.toSorted().
    *
    * This comparator will ignore things like accent marks, case, and punctuation.
+   * Ignoring punctuation also ignores spaces, so this should check word by word.
    *
    * @param x - The first element for comparison.
    * @param y - The second element for comparison.
    * @returns A number indicating whether or not the first param is greater than the second param.
    */
-  static compare = new Intl.Collator("en", {
-    numeric: true,
-    sensitivity: "base",
-    ignorePunctuation: true,
-  }).compare;
+  static compare(x: string, y: string) {
+    // Skip if they're the same
+    if (x == y) {
+      return 0;
+    }
+
+    const intlComparator = new Intl.Collator("en", {
+      numeric: true,
+      sensitivity: "base",
+      ignorePunctuation: true,
+    }).compare;
+
+    const xParts = x.split(" ");
+    const yParts = y.split(" ");
+
+    // Maximum index checkable in the bounds of the arrays
+    const maxIndex = Math.min(xParts.length, yParts.length);
+
+    // Compare the first word in the name string that differs
+    for (let i = 0; i < maxIndex; i++) {
+      const xAtIndex = xParts[i] || "";
+      const yAtIndex = yParts[i] || "";
+
+      if (xAtIndex !== yAtIndex) {
+        return intlComparator(xAtIndex, yAtIndex);
+      }
+    }
+
+    // Handle if names are almost the same but one is longer
+    return intlComparator(x, y);
+  }
 }
 
 export { SortableNames };


### PR DESCRIPTION
Now it will sort on a word by word basis instead of a letter by letter basis. This means a name like Dick will always come before a name like Dickey instead of the unexpected behavior seen previously.

BREAKING CHANGE: may change the sorted order of items previously sorted with the compare helper.

Fixes #7